### PR TITLE
Remove cache from setup-venv action

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -12,23 +12,9 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    
-    - name: Get Cache Date
-      shell: bash
-      id: get-cache-date
-      run: |
-        echo "date=$(/bin/date -u "+%Y%U")" >> $GITHUB_OUTPUT
-
-    - name: Cache virtualenv
-      id: cache-venv
-      uses: actions/cache@v4
-      with:
-        path: ${{ inputs.venv-path }}
-        key: ${{ steps.get-cache-date.outputs.date }}-${{ hashfiles('pyproject.toml', 'poetry.lock') }}
 
     - name: Setup venv
       shell: bash
-      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python3 -m venv .venv
         .venv/bin/pip install "poetry>=1.8.2<2"


### PR DESCRIPTION
# Context
The caching step for setting up the python virtualenv is not working as expected. This PR removes the cache step