### PR TITLE
Fix URLs in single-dataset citations

### DIFF
--- a/content/other/learning-dynamics-incoherently/citation.txt
+++ b/content/other/learning-dynamics-incoherently/citation.txt
@@ -9,5 +9,5 @@
 @misc{jerbi2024learning,
   title = {Learning Dynamics Incoherently},  
   author = {Sofiene Jerbi and Joe Gibbs and Manuel S. Rudolph and Matthias C. Caro and Patrick J. Coles and Hsin-Yuan Huang and Zoë Holmes}, 
-  howpublished = {\url{https://pennylane.ai/datasets/other/learning-dynamics-incoherently}}, 
+  howpublished = {\url{https://pennylane.ai/datasets/single-dataset/learning-dynamics-incoherently}}, 
   year = {2024}}

--- a/content/other/plus-minus/citation.txt
+++ b/content/other/plus-minus/citation.txt
@@ -1,7 +1,7 @@
 @misc{wendlinger2024plusminus,
     title={Plus Minus},
     author={Maximilian Wendlinger and Kilian Tscharke and Pascal Debus},
-    howpublished={\url{https://pennylane.ai/datasets/other/plus-minus}},
+    howpublished={\url{https://pennylane.ai/datasets/single-dataset/plus-minus}},
     year={2024}
 }
 

--- a/content/other/rydberggpt/citation.txt
+++ b/content/other/rydberggpt/citation.txt
@@ -1,7 +1,7 @@
 @misc{fitzek2024rydberggptdata,
     title={PennyLane Datasets for RydbergGPT}, 
     author={Fitzek, David and Teoh, Yi Hong and Fung, Hin Pok and Dagnew, Gebremedhin A and Merali, Ejaaz and Moss, M Schuyler and MacLellan, Benjamin and Melko, Roger G},
-    howpublished = {\url{https://pennylane.ai/datasets/other/rydberggpt}}
+    howpublished = {\url{https://pennylane.ai/datasets/single-dataset/rydberggpt}}
     year={2024}
 }
 

--- a/content/other/t-optimize/citation.txt
+++ b/content/other/t-optimize/citation.txt
@@ -1,6 +1,6 @@
 @misc{Kottmann2024_op-T-mize,
     title={T-gate optimization},
     author={Korbinian Kottmann},
-    howpublished={\urlhttps://pennylane.ai/datasets/other/op-T-mize},
+    howpublished={\urlhttps://pennylane.ai/datasets/single-dataset/op-T-mize},
     year={2024}
 }


### PR DESCRIPTION
Citations were pointing to `pennylane.ai/datasets/other/dataset-name` instead of the correct `pennylane.ai/datasets/single-dataset/dataset-name`