### PR TITLE
Fix poetry version spec in `setup-venv` action

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -17,5 +17,5 @@ runs:
       shell: bash
       run: |
         python3 -m venv .venv
-        .venv/bin/pip install "poetry>=1.8.2<2"
+        .venv/bin/pip install "poetry>=1.8.2,<2"
         .venv/bin/poetry install --with dev --no-root


### PR DESCRIPTION
# Changes
- Fix version spec for poetry to prevent install of `2.0` version