### PR TITLE
Add missing 2.1 bondlength to N2 molecule

### DIFF
--- a/content/qchem/n2-molecule/dataset.json
+++ b/content/qchem/n2-molecule/dataset.json
@@ -125,6 +125,19 @@
       }
     },
     {
+      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/qchem/N2/STO-3G/2.1/N2_STO-3G_2.1.h5",
+      "parameters": {
+        "molname": "N2",
+        "basis": "STO-3G",
+        "bondlength": "2.1",
+        "bondangle": "N\\A",
+        "number_of_spin_orbitals": "20"
+      },
+      "extra": {
+        "hamiltonianTerms": "N/A"
+      }
+    },
+    {
       "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/qchem/N2/STO-3G/2.3/N2_STO-3G_2.3.h5",
       "parameters": {
         "molname": "N2",


### PR DESCRIPTION
Found that the bondlength 2.1 exists in S3 and on the foldermap, but not on the datasets service. It wasn't downloadable and didn't appear on the front-end.

This PR adds the metadata for bondlength 2.1 to make sure it is downloadable and appears on the frontend.

Pending:

- [ ]  Add Hamiltonian terms for the preview