### PR TITLE
Fix file uploads greater than 2GB in size

### DIFF
--- a/lib/dsets/app.py
+++ b/lib/dsets/app.py
@@ -385,7 +385,7 @@ def deploy_build():
         )
     else:
         msg.structured_print(
-            "Environment variable 'DATASETS_ADMIN_API_URL' is unset," " cannot deploy."
+            "Environment variable 'DATASETS_ADMIN_API_URL' is unset, cannot deploy."
         )
         typer.Exit(1)
 

--- a/lib/dsets/lib/graphql/files.py
+++ b/lib/dsets/lib/graphql/files.py
@@ -20,7 +20,7 @@ class File(TypedDict):
 
     name: str
     status: str
-    size: int
+    size: str
     downloadUrl: str
     checksumSha256: str
 
@@ -29,8 +29,8 @@ class FileUploadPart(TypedDict):
     """Part of a ``FileUpload``."""
 
     url: str
-    bytesStart: int
-    bytesEnd: int
+    bytesStart: str
+    bytesEnd: str
 
 
 class FileUpload(TypedDict):
@@ -47,7 +47,7 @@ def _create_file_upload(
     """Create a new file upload."""
     resp = client.execute(
         queries.UPLOAD_CREATE,
-        {"name": name, "size": size, "checksum_sha256": checksum_sha256.hex()},
+        {"name": name, "size": str(size), "checksum_sha256": checksum_sha256.hex()},
         parse_result=True,
     )["datasetFileUploadCreate"]
     if resp.get("userError"):
@@ -92,7 +92,7 @@ def upload_file(
 
     while (upload := _get_file_upload(client, name)) is not None:
         for part in upload["uploadParts"]:
-            start, end = part["bytesStart"], part["bytesEnd"]
+            start, end = int(part["bytesStart"]), int(part["bytesEnd"])
             stream.seek(start)
 
             requests.put(part["url"], data=stream.read(end - start)).raise_for_status()

--- a/lib/dsets/lib/graphql/queries.py
+++ b/lib/dsets/lib/graphql/queries.py
@@ -2,7 +2,7 @@ from gql import gql
 
 UPLOAD_CREATE = gql(
     """
-mutation CreateUpload($name: String!, $checksum_sha256: String!, $size: Int!) {
+mutation CreateUpload($name: String!, $checksum_sha256: String!, $size: StrInt!) {
   datasetFileUploadCreate(
     name: $name
     checksumSha256: $checksum_sha256


### PR DESCRIPTION
# Changes
- Update dataset file upload API prototypes to use `str` for upload file size and byte boundaries. This change was made to fix bugs when file uploads were bigger than ~2GB