### PR TITLE
Add default value to prompt for image

### DIFF
--- a/lib/dsets/app.py
+++ b/lib/dsets/app.py
@@ -50,7 +50,7 @@ def _prompt_for_image(prompt: str, dest_dir: Path) -> Path | None:
     """Prompt the user for an image. And attempt to move it to directory
     `dest`."""
 
-    src = typer.prompt(prompt).strip()
+    src = typer.prompt(prompt, default="").strip()
     if not src:
         return None
 


### PR DESCRIPTION
Without this the prompt `Enter path to banner image (leave blank to continue) []:`
could not be left blank and would loop indefinitely 