### PR TITLE
Fix downloads by updating URLs to MNISQ, TSP, max-3-sat

### DIFF
--- a/content/other/hamlib/hamlib-max-3-sat/dataset.json
+++ b/content/other/hamlib/hamlib-max-3-sat/dataset.json
@@ -41,7 +41,7 @@
   },
   "data": [
     {
-      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/other/Max3Sat/Max3Sat_Max3Sat.h5",
+      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/tmp/Max3Sat/Max3Sat_Max3Sat.h5",
       "parameters": {
         "name": "hamlib-max-3-sat"
       },

--- a/content/other/hamlib/hamlib-travelling-salesperson-problem/dataset.json
+++ b/content/other/hamlib/hamlib-travelling-salesperson-problem/dataset.json
@@ -31,7 +31,7 @@
   },
   "data": [
     {
-      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/other/TSP/TSP_TSP.h5",
+      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/tmp/TSP/TSP_TSP.h5",
       "parameters": {
         "name": "hamlib-travelling-salesperson-problem"
       },

--- a/content/other/mnisq/dataset.json
+++ b/content/other/mnisq/dataset.json
@@ -28,7 +28,7 @@
   },
   "data": [
     {
-      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/other/MNISQ/MNISQ_MNISQ.h5",
+      "dataUrl": "https://datasets.cloud.pennylane.ai/datasets/h5/tmp/MNISQ/MNISQ_MNISQ.h5",
       "parameters": {
         "name": "mnisq"
       },


### PR DESCRIPTION
Three datasets were downloading empty files because the URL was pointing to old test files:
* Hamlib: max-3-sat
* MNISQ
* Hamlib: TSP

This PR updates the URLs to point to the correct files.

[Related forum post](https://discuss.pennylane.ai/t/not-working-hamlib/9143)