### PR TITLE
Update `/qml/demos/` URLs to `/demos/` across dataset documentation

### DIFF
--- a/content/other/learning-dynamics-incoherently/meta.json
+++ b/content/other/learning-dynamics-incoherently/meta.json
@@ -44,6 +44,6 @@
   "heroImage": "https://assets.cloud.pennylane.ai/datasets/generic/hero/pennylane-datasets-hero-generic-2.png",
   "thumbnail": "https://assets.cloud.pennylane.ai/datasets/generic/thumbnail/pennylane-datasets-thumbnail-learning-dynamics-incoherently.png",
   "extra": {},
-  "dateOfLastModification": "2026-04-23",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/other/learning-dynamics-incoherently/using_this_dataset.md
+++ b/content/other/learning-dynamics-incoherently/using_this_dataset.md
@@ -13,7 +13,7 @@ These questions are addressed in detail by Jerbi et al.
 They demonstrate one way to reproduce the unknown operator is to train a variational quantum circuit that learns to produce the same output.
 
 This dataset provides data used by the authors to demonstrate this method. 
-For this demonstration, two training states were drawn from the [Haar random distribution](https://pennylane.ai/qml/demos/tutorial_haar_measure/)
+For this demonstration, two training states were drawn from the [Haar random distribution](https://pennylane.ai/demos/tutorial_haar_measure/)
 as initial states. A variational quantum circuit was applied to these initial states and its parameters were optimized with respect to a cost function
 (see equation 5).
 After optimization, the output of the variational circuit approximated the output of a target Trotterized transverse-field Ising Hamiltonian.

--- a/content/other/phase-angles/cos/meta.json
+++ b/content/other/phase-angles/cos/meta.json
@@ -14,7 +14,7 @@
   ],
   "description": "Dataset of phase angles to implement cos(x) using qsp or qsvt",
   "license": "[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)",
-  "dateOfLastModification": "2026-04-23",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2025-06-16",
   "sourceCodeUrl": null,
   "tags": [],

--- a/content/other/phase-angles/cos/using_this_dataset.md
+++ b/content/other/phase-angles/cos/using_this_dataset.md
@@ -1,4 +1,4 @@
-This dataset contains phase angles to approximate the function $cos(x)$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/qml/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/qml/demos/tutorial_intro_qsvt).
+This dataset contains phase angles to approximate the function $cos(x)$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/demos/tutorial_intro_qsvt).
 
 **Description of the dataset**
 

--- a/content/other/phase-angles/inverse/meta.json
+++ b/content/other/phase-angles/inverse/meta.json
@@ -14,7 +14,7 @@
   ],
   "description": "Dataset of phase angles to implement 1/x using qsp or qsvt",
   "license": "[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)",
-  "dateOfLastModification": "2026-04-23",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2025-06-16",
   "sourceCodeUrl": null,
   "tags": [],

--- a/content/other/phase-angles/inverse/using_this_dataset.md
+++ b/content/other/phase-angles/inverse/using_this_dataset.md
@@ -1,4 +1,4 @@
-This dataset contains phase angles to approximate the function $1/x$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/qml/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/qml/demos/tutorial_intro_qsvt).
+This dataset contains phase angles to approximate the function $1/x$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/demos/tutorial_intro_qsvt).
 
 **Description of the dataset**
 

--- a/content/other/phase-angles/sin/meta.json
+++ b/content/other/phase-angles/sin/meta.json
@@ -14,7 +14,7 @@
   ],
   "description": "Dataset of phase angles to implement sin(x) using qsp or qsvt",
   "license": "[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en)",
-  "dateOfLastModification": "2026-04-23",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2025-06-16",
   "sourceCodeUrl": null,
   "tags": [],

--- a/content/other/phase-angles/sin/using_this_dataset.md
+++ b/content/other/phase-angles/sin/using_this_dataset.md
@@ -1,4 +1,4 @@
-This dataset contains phase angles to approximate the function $sin(x)$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/qml/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/qml/demos/tutorial_intro_qsvt).
+This dataset contains phase angles to approximate the function $sin(x)$ via [Quantum Signal Processing (QSP)](https://pennylane.ai/demos/function_fitting_qsp) and [Quantum Singular Value Transformation (QSVT)](https://pennylane.ai/demos/tutorial_intro_qsvt).
 
 **Description of the dataset**
 

--- a/content/other/plus-minus/meta.json
+++ b/content/other/plus-minus/meta.json
@@ -33,6 +33,6 @@
   "heroImage": "https://assets.cloud.pennylane.ai/datasets/generic/hero/pennylane-datasets-hero-generic-2.png",
   "thumbnail": "https://assets.cloud.pennylane.ai/datasets/generic/thumbnail/pennylane-datasets-thumbnail-adversarial-robustness.png",
   "extra": {},
-  "dateOfLastModification": "2026-04-23",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-16"
 }

--- a/content/other/plus-minus/using_this_dataset.md
+++ b/content/other/plus-minus/using_this_dataset.md
@@ -6,7 +6,7 @@ The train (test) dataset consists of 1000 (200) images split into four classes. 
 
 For a detailed introduction to adversarial robustness and to reproduce some of
 the investigation by Wendlinger et al., see the
-[Adversarial attacks and robustness for quantum machine learning demo](https://pennylane.ai/qml/demos/tutorial_adversarial_attacks_QML/).
+[Adversarial attacks and robustness for quantum machine learning demo](https://pennylane.ai/demos/tutorial_adversarial_attacks_QML/).
 
 **Additional details**
 

--- a/content/qchem/beh2-molecule/meta.json
+++ b/content/qchem/beh2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/beh2-molecule/using_this_dataset.md
+++ b/content/qchem/beh2-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/bh3-molecule/meta.json
+++ b/content/qchem/bh3-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/bh3-molecule/using_this_dataset.md
+++ b/content/qchem/bh3-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/c2-molecule/meta.json
+++ b/content/qchem/c2-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/c2-molecule/using_this_dataset.md
+++ b/content/qchem/c2-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/c2h2-molecule/meta.json
+++ b/content/qchem/c2h2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/c2h2-molecule/using_this_dataset.md
+++ b/content/qchem/c2h2-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/c2h4-molecule/meta.json
+++ b/content/qchem/c2h4-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/c2h4-molecule/using_this_dataset.md
+++ b/content/qchem/c2h4-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/c2h6-molecule/meta.json
+++ b/content/qchem/c2h6-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/c2h6-molecule/using_this_dataset.md
+++ b/content/qchem/c2h6-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/ch2-molecule/meta.json
+++ b/content/qchem/ch2-molecule/meta.json
@@ -32,6 +32,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/ch2-molecule/using_this_dataset.md
+++ b/content/qchem/ch2-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/ch2o-molecule/meta.json
+++ b/content/qchem/ch2o-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/ch2o-molecule/using_this_dataset.md
+++ b/content/qchem/ch2o-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/ch4-molecule/meta.json
+++ b/content/qchem/ch4-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/ch4-molecule/using_this_dataset.md
+++ b/content/qchem/ch4-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/co-molecule/meta.json
+++ b/content/qchem/co-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/co-molecule/using_this_dataset.md
+++ b/content/qchem/co-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/co2-molecule/meta.json
+++ b/content/qchem/co2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/co2-molecule/using_this_dataset.md
+++ b/content/qchem/co2-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h10-molecule/meta.json
+++ b/content/qchem/h10-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h10-molecule/using_this_dataset.md
+++ b/content/qchem/h10-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h2-molecule/meta.json
+++ b/content/qchem/h2-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h2-molecule/using_this_dataset.md
+++ b/content/qchem/h2-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h2o-molecule/meta.json
+++ b/content/qchem/h2o-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h2o-molecule/using_this_dataset.md
+++ b/content/qchem/h2o-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h2o2-molecule/meta.json
+++ b/content/qchem/h2o2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h2o2-molecule/using_this_dataset.md
+++ b/content/qchem/h2o2-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h3-cation/meta.json
+++ b/content/qchem/h3-cation/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h3-cation/using_this_dataset.md
+++ b/content/qchem/h3-cation/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h4-molecule/meta.json
+++ b/content/qchem/h4-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h4-molecule/using_this_dataset.md
+++ b/content/qchem/h4-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h5-molecule/meta.json
+++ b/content/qchem/h5-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h5-molecule/using_this_dataset.md
+++ b/content/qchem/h5-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h6-molecule/meta.json
+++ b/content/qchem/h6-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h6-molecule/using_this_dataset.md
+++ b/content/qchem/h6-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h7-molecule/meta.json
+++ b/content/qchem/h7-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h7-molecule/using_this_dataset.md
+++ b/content/qchem/h7-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/h8-molecule/meta.json
+++ b/content/qchem/h8-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/h8-molecule/using_this_dataset.md
+++ b/content/qchem/h8-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/hcn-molecule/meta.json
+++ b/content/qchem/hcn-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/hcn-molecule/using_this_dataset.md
+++ b/content/qchem/hcn-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/he2-molecule/meta.json
+++ b/content/qchem/he2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/he2-molecule/using_this_dataset.md
+++ b/content/qchem/he2-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/heh-cation/meta.json
+++ b/content/qchem/heh-cation/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/heh-cation/using_this_dataset.md
+++ b/content/qchem/heh-cation/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/hf-molecule/meta.json
+++ b/content/qchem/hf-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/hf-molecule/using_this_dataset.md
+++ b/content/qchem/hf-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/li2-molecule/meta.json
+++ b/content/qchem/li2-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/li2-molecule/using_this_dataset.md
+++ b/content/qchem/li2-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/lih-molecule/meta.json
+++ b/content/qchem/lih-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/lih-molecule/using_this_dataset.md
+++ b/content/qchem/lih-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/n2-molecule/meta.json
+++ b/content/qchem/n2-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/n2-molecule/using_this_dataset.md
+++ b/content/qchem/n2-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/n2h2-molecule/meta.json
+++ b/content/qchem/n2h2-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/n2h2-molecule/using_this_dataset.md
+++ b/content/qchem/n2h2-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/n2h4-molecule/meta.json
+++ b/content/qchem/n2h4-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/n2h4-molecule/using_this_dataset.md
+++ b/content/qchem/n2h4-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/neh-cation/meta.json
+++ b/content/qchem/neh-cation/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/neh-cation/using_this_dataset.md
+++ b/content/qchem/neh-cation/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/nh3-molecule/meta.json
+++ b/content/qchem/nh3-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/nh3-molecule/using_this_dataset.md
+++ b/content/qchem/nh3-molecule/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/o2-molecule/meta.json
+++ b/content/qchem/o2-molecule/meta.json
@@ -35,6 +35,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/o2-molecule/using_this_dataset.md
+++ b/content/qchem/o2-molecule/using_this_dataset.md
@@ -3,8 +3,8 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/o3-molecule/meta.json
+++ b/content/qchem/o3-molecule/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/o3-molecule/using_this_dataset.md
+++ b/content/qchem/o3-molecule/using_this_dataset.md
@@ -3,7 +3,7 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:

--- a/content/qchem/oh-anion/meta.json
+++ b/content/qchem/oh-anion/meta.json
@@ -34,6 +34,6 @@
     "version 0.2 : added initial states\n",
     "version 0.1 : initial public release"
   ],
-  "dateOfLastModification": "2025-06-16",
+  "dateOfLastModification": "2026-05-28",
   "dateOfPublication": "2024-09-11"
 }

--- a/content/qchem/oh-anion/using_this_dataset.md
+++ b/content/qchem/oh-anion/using_this_dataset.md
@@ -3,9 +3,9 @@ This dataset contains various quantum properties that represent and describe the
 Key features include:
 
 - Jordan-Wigner Hamiltonian representation
-- [Molecule geometry information](https://pennylane.ai/qml/demos/tutorial_quantum_chemistry)
-- [Qubit-wise commuting groups](https://pennylane.ai/qml/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
-- [Givens rotations-based](https://pennylane.ai/qml/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
+- [Molecule geometry information](https://pennylane.ai/demos/tutorial_quantum_chemistry)
+- [Qubit-wise commuting groups](https://pennylane.ai/demos/tutorial_measurement_optimize) for hardware measurements, including simulated output samples
+- [Givens rotations-based](https://pennylane.ai/demos/tutorial_givens_rotations) ansatz with optimal parameters for VQE
 - Approximations to the ground state of varying quality, from exact to 0.1% overlap
 
 It can be used to:


### PR DESCRIPTION
Remove `/qml` prefix from all pennylane.ai demo URLs to match the current site routing structure (`pennylane.ai/demos/` instead of `pennylane.ai/qml/demos/`).

- Authored by Jukebox 🤖 